### PR TITLE
Make navigation come before tags

### DIFF
--- a/layouts/partials/mobile-header-nav.html
+++ b/layouts/partials/mobile-header-nav.html
@@ -31,41 +31,7 @@
         </svg>
     </button>
     {{end}}
-    <div class="mb-header-nav__wrapper">
-        <div class="mb-header-nav__container">
-            <svg
-                width="240"
-                height="72"
-                viewBox="0 0 240 72"
-                class="mb-header-nav__title"
-                >
-                <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle">
-                Tags
-                </text>
-            </svg>
-            <ul class="mb-header-nav-list">
-                {{if .IsHome}}
-                {{ range .Site.Taxonomies.tags }}
-                  <li class="mb-header-nav-list__item {{ if $cssonly }} cssonly {{ end }}">
-                        <a class="mb-header-nav-list__link" href="{{ .Page.Permalink}}"
-                                                            >{{.Page.Title}}</a
-                                                        >
-                    </li>
-                        {{end}}
-                {{else}}
-                    {{range .Params.tags}}
-                        {{with $.Site.GetPage (printf "/%s/%s" "tags" ( . | urlize ))}}
-                          <li class="mb-header-nav-list__item {{if $cssonly}} cssonly {{end}}">
-                        <a class="mb-header-nav-list__link" href="{{ .Permalink}}"
-                                                            >{{.Title}}</a
-                                                        >
-                    </li>
-                        {{end}}
-                    {{end}}
-                {{end}}
-            </ul>
-        </div>
-        <div class="mb-header-nav__container">
+  <div class="mb-header-nav__container">
             <svg
                 width="240"
                 height="72"
@@ -101,6 +67,40 @@
                         </li>
                     {{ end }}
                 {{ end }}
+            </ul>
+        </div>
+    <div class="mb-header-nav__wrapper">
+        <div class="mb-header-nav__container">
+            <svg
+                width="240"
+                height="72"
+                viewBox="0 0 240 72"
+                class="mb-header-nav__title"
+                >
+                <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle">
+                Tags
+                </text>
+            </svg>
+            <ul class="mb-header-nav-list">
+                {{if .IsHome}}
+                {{ range .Site.Taxonomies.tags }}
+                  <li class="mb-header-nav-list__item {{ if $cssonly }} cssonly {{ end }}">
+                        <a class="mb-header-nav-list__link" href="{{ .Page.Permalink}}"
+                                                            >{{.Page.Title}}</a
+                                                        >
+                    </li>
+                        {{end}}
+                {{else}}
+                    {{range .Params.tags}}
+                        {{with $.Site.GetPage (printf "/%s/%s" "tags" ( . | urlize ))}}
+                          <li class="mb-header-nav-list__item {{if $cssonly}} cssonly {{end}}">
+                        <a class="mb-header-nav-list__link" href="{{ .Permalink}}"
+                                                            >{{.Title}}</a
+                                                        >
+                    </li>
+                        {{end}}
+                    {{end}}
+                {{end}}
             </ul>
         </div>
     </div>


### PR DESCRIPTION
It makes a lot more sense for navigation to come before tags on mobile since tags are more of a searching tool while navigation is fixed points for users to look at.