### PR TITLE
Add / to favicon path

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -16,7 +16,7 @@
     <meta name="twitter:description" content="{{if .IsHome}}{{ .Site.Params.description }}{{else}}{{.Description}}{{end}}"/>
 
     <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="favicon-32.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
 
     {{ $style := resources.Get "scss/style.scss" | resources.ToCSS | resources.Minify | resources.Fingerprint }}
     <link rel="stylesheet" href="{{$style.Permalink}}" >


### PR DESCRIPTION
This fixes a bug where the favicon doesn't work on any page other than the homepage due to the href tag being a relative URL. Switching from `favicon-32.png` to `/favicon-32.png` means the browser will always fetch the favicon from the correct URL on all pages.